### PR TITLE
change signature of Get method

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ bool deleted = msg.Delete();
 
 Console.WriteLine("Deleted = {0}", deleted);
 
+// Post several messages
+queue.Post(new[] { "Hello", "world" });
+
+MessageCollection messages = queue.Get(n: 2, timeout: 60, wait: 30);
+// You can specify only parameters you need:
+// MessageCollection messages = queue.Get(wait: 15);
+
+// Post several messages
 var payload1 = new
 {
     message = "hello, my name is Iron.io 1"

--- a/src/Demo.IronSharp/Program.cs
+++ b/src/Demo.IronSharp/Program.cs
@@ -79,6 +79,14 @@ namespace Demo.IronSharpConsole
 
             Console.WriteLine("Deleted = {0}", deleted);
 
+            // Post several messages
+            queue.Post(new[] { "Hello", "world" });
+
+            MessageCollection messages = queue.Get(n: 2, timeout: 60, wait: 30);
+            // You can specify only parameters you need:
+            // MessageCollection messages = queue.Get(wait: 15);
+
+            // Post several messages
             var payload1 = new
             {
                 message = "hello, my name is Iron.io 1"

--- a/src/IronSharp.IronMQ/QueueClient.cs
+++ b/src/IronSharp.IronMQ/QueueClient.cs
@@ -288,7 +288,7 @@ namespace IronSharp.IronMQ
         /// http://dev.iron.io/mq/reference/api/#get_messages_from_a_queue
         /// https://github.com/iron-io/iron_mq_ruby#get-messages-from-a-queue
         /// </remarks>
-        public MessageCollection Get(int? n, int? timeout, int? wait)
+        public MessageCollection Get(int? n = null, int? timeout = null, int? wait = null)
         {
             var query = new NameValueCollection();
 


### PR DESCRIPTION
@Stephenitis, I left Next method as it was in docs, but...

> this function pattern looks bananas to me, if there is a reason for Next to call Next I'd love to know.

Next() method was implemented by Jeremy Bell, author of the lib we forked. Such method name is familiar to .Net developers and widely used in various libraries including Framework Class Library for operation of getting of an element from some sequence.

As of now, Next and Get methods are left in v3 only for backward compatibility. And we can get rid of them soon )

> QueueMessage msg = queue.Get(30, 60, 100);

and 

> QueueMessage msg = queue.Get(n:30, timeout: 60, wait: 100);

Wait can not be greater than 30 according to http://dev.iron.io/mq/reference/api/#get_messages_from_a_queue
