### PR TITLE
replace ObjectDisposedException with more user friendly one

### DIFF
--- a/src/IronSharp.Core/Exceptions/RestResponseException.cs
+++ b/src/IronSharp.Core/Exceptions/RestResponseException.cs
@@ -42,7 +42,14 @@ namespace IronSharp.Core
 
                 if (request.Content != null)
                 {
-                    sw.WriteLine(request.Content.ReadAsStringAsync().Result);
+                    try
+                    {
+                        sw.WriteLine(request.Content.ReadAsStringAsync().Result);
+                    }
+                    catch (Exception e)
+                    {
+                        sw.WriteLine("Unable to read response content. " + e.Message);
+                    }                    
                 }
 
                 return sw.ToString();


### PR DESCRIPTION
We received a stacktrace from Zakupki:

```
System.ObjectDisposedException: Доступ к ликвидированному объекту невозможен. 
Имя объекта: "IronSharp.Core.JsonContent". 
в System.Net.Http.HttpContent.ReadAsStringAsync() 
в IronSharp.Core.RestResponseException.AppendDebugInfo(HttpResponseMessage response) в c:\Users\admin\Documents\GitHub\iron_dotnet\src\IronSharp.Core\Exceptions\RestResponseException.cs:строка 45 
в IronSharp.Core.RestResponseException..ctor(String message, HttpResponseMessage response) в c:\Users\admin\Documents\GitHub\iron_dotnet\src\IronSharp.Core\Exceptions\RestResponseException.cs:строка 9 
в IronSharp.IronMQ.QueueClient.Get(Nullable`1 n, Nullable`1 timeout, Nullable`1 wait) в c:\Users\admin\Documents\GitHub\iron_dotnet\src\IronSharp.IronMQ\QueueClient.cs:строка 340 
в IronSharp.IronMQ.QueueClient.Next(Nullable`1 timeout) в c:\Users\admin\Documents\GitHub\iron_dotnet\src\IronSharp.IronMQ\QueueClient.cs:строка 390 
в ByndyuSoft.Zakupki360.Infrastructure.DataAccess.IronMQ.Sources.MqQuery`1.Ask(IQueueCriterion criterion) в c:\Development\zakupki360\Mlg.Spending.Web\sources\Zakupki360.Infrastructure.DataAccess.IronMQ\Sources\MqQuery.cs:строка 29
```

We needn't to throw exception from constructor of our exception. So I surrounded  `request.Content.ReadAsStringAsync()` with try-catch
