### PR TITLE
Workaround for a bug with access to disposed object

### DIFF
--- a/src/IronSharp.Core/RestClient.cs
+++ b/src/IronSharp.Core/RestClient.cs
@@ -50,7 +50,7 @@ namespace IronSharp.Core
 
             if (payload != null)
             {
-                requestBuilder.RequestContent = new JsonContent(payload);
+                requestBuilder.Payload = payload;
             }
 
             return new RestResponse<T>(AttemptRequest(sharpConfig, requestBuilder));
@@ -94,7 +94,7 @@ namespace IronSharp.Core
 
             if (payload != null)
             {
-                requestBuilder.RequestContent = new JsonContent(payload);
+                requestBuilder.Payload = payload;
             }
 
             return new RestResponse<T>(AttemptRequest(sharpConfig, requestBuilder));
@@ -113,7 +113,7 @@ namespace IronSharp.Core
 
             if (payload != null)
             {
-                requestBuilder.RequestContent = new JsonContent(payload);
+                requestBuilder.Payload = payload;
             }
 
             return new RestResponse<T>(AttemptRequest(sharpConfig, requestBuilder));

--- a/src/IronSharp.Core/Types/HttpRequestMessageBuilder.cs
+++ b/src/IronSharp.Core/Types/HttpRequestMessageBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using IronSharp.Core.Abstract;
 
@@ -8,7 +9,7 @@ namespace IronSharp.Core.Types
     {
         public IronClientConfig Config { get; set; }
         public IRestClientRequest Request { get; set; }
-        public HttpContent RequestContent { get; set; }
+        public Object Payload { get; set; }
         public IRequestHelpersContainer RequestHelpersContainer { get; set; }
 
         public HttpRequestMessageBuilder(IronClientConfig config, IRequestHelpersContainer requestHelpersContainer, IRestClientRequest request)
@@ -23,7 +24,7 @@ namespace IronSharp.Core.Types
             RequestHelpersContainer.SetOathQueryParameterIfRequired(Request, Config.Token);
             var httpRequest = new HttpRequestMessage
             {
-                Content = RequestContent ?? Request.Content,
+                Content = Payload != null ? new JsonContent(Payload) : Request.Content,
                 RequestUri = RequestHelpersContainer.BuildUri(Config, Request.EndPoint, Request.Query),
                 Method = Request.Method
             };


### PR DESCRIPTION
--------

p.s. It's not perfect idea to hardcode wrapping payload by only JsonContent inside the HttpRequestMessageBuilder, but I think we could refactor it when we will need another type of content.