### PR TITLE
Make RestClient non-static

### DIFF
--- a/src/IronSharp.IronCache/CacheClient.cs
+++ b/src/IronSharp.IronCache/CacheClient.cs
@@ -8,6 +8,7 @@ namespace IronSharp.IronCache
     {
         private readonly string _cacheName;
         private readonly IronCacheRestClient _client;
+        protected readonly RestClient _restClient; 
 
         public CacheClient(IronCacheRestClient client, string cacheName)
         {
@@ -17,6 +18,7 @@ namespace IronSharp.IronCache
 
             _client = client;
             _cacheName = cacheName;
+            _restClient = client.RestClient;
         }
 
         public IValueSerializer ValueSerializer
@@ -32,12 +34,12 @@ namespace IronSharp.IronCache
         /// </remarks>
         public bool Clear()
         {
-            return RestClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/clear", CacheNameEndPoint())).HasExpectedMessage("Deleted.");
+            return _restClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/clear", CacheNameEndPoint())).HasExpectedMessage("Deleted.");
         }
 
         public bool Delete(string key)
         {
-            return RestClient.Delete<ResponseMsg>(_client.Config, CacheItemEndPoint(key)).HasExpectedMessage("Deleted.");
+            return _restClient.Delete<ResponseMsg>(_client.Config, CacheItemEndPoint(key)).HasExpectedMessage("Deleted.");
         }
 
         /// <summary>
@@ -49,7 +51,7 @@ namespace IronSharp.IronCache
         /// </remarks>
         public CacheItem Get(string key)
         {
-            RestResponse<CacheItem> response = RestClient.Get<CacheItem>(_client.Config, CacheItemEndPoint(key));
+            RestResponse<CacheItem> response = _restClient.Get<CacheItem>(_client.Config, CacheItemEndPoint(key));
 
             if (response.CanReadResult())
             {
@@ -111,7 +113,7 @@ namespace IronSharp.IronCache
         /// </remarks>
         public CacheIncrementResult Increment(string key, int amount = 1)
         {
-            return RestClient.Post<CacheIncrementResult>(_client.Config, string.Format("{0}/increment", CacheItemEndPoint(key)), new {amount});
+            return _restClient.Post<CacheIncrementResult>(_client.Config, string.Format("{0}/increment", CacheItemEndPoint(key)), new { amount });
         }
 
         /// <summary>
@@ -122,7 +124,7 @@ namespace IronSharp.IronCache
         /// </remarks>
         public CacheInfo Info()
         {
-            return RestClient.Get<CacheInfo>(_client.Config, CacheNameEndPoint());
+            return _restClient.Get<CacheInfo>(_client.Config, CacheNameEndPoint());
         }
 
         public bool Put(string key, object value, CacheItemOptions options = null)
@@ -150,7 +152,7 @@ namespace IronSharp.IronCache
         /// </remarks>
         public bool Put(string key, CacheItem item)
         {
-            return RestClient.Put<ResponseMsg>(_client.Config, CacheItemEndPoint(key), item).HasExpectedMessage("Stored.");
+            return _restClient.Put<ResponseMsg>(_client.Config, CacheItemEndPoint(key), item).HasExpectedMessage("Stored.");
         }
 
         private static bool IsDefaultValue(CacheItem item)

--- a/src/IronSharp.IronCache/IronCacheRestClient.cs
+++ b/src/IronSharp.IronCache/IronCacheRestClient.cs
@@ -8,10 +8,12 @@ namespace IronSharp.IronCache
     public class IronCacheRestClient
     {
         private readonly IronClientConfig _config;
+        protected readonly RestClient _restClient; 
 
         internal IronCacheRestClient(IronClientConfig config)
         {
             _config = LazyInitializer.EnsureInitialized(ref config);
+            _restClient = new RestClient();
 
             if (string.IsNullOrEmpty(Config.Host))
             {
@@ -27,6 +29,11 @@ namespace IronSharp.IronCache
         public IronClientConfig Config
         {
             get { return _config; }
+        }
+
+        public RestClient RestClient
+        {
+            get { return _restClient; }
         }
 
         public string EndPoint
@@ -49,7 +56,7 @@ namespace IronSharp.IronCache
         /// </remarks>
         public bool Delete(string cacheName)
         {
-            return RestClient.Delete<ResponseMsg>(_config, string.Format("{0}/{1}", EndPoint, cacheName)).HasExpectedMessage("Deleted.");
+            return _restClient.Delete<ResponseMsg>(_config, string.Format("{0}/{1}", EndPoint, cacheName)).HasExpectedMessage("Deleted.");
         }
 
         /// <summary>
@@ -68,7 +75,7 @@ namespace IronSharp.IronCache
                 query.Add("page", Convert.ToString(page));
             }
 
-            return RestClient.Get<CacheInfo[]>(_config, EndPoint, query);
+            return _restClient.Get<CacheInfo[]>(_config, EndPoint, query);
         }
     }
 }

--- a/src/IronSharp.IronMQ/IronMqRestClient.cs
+++ b/src/IronSharp.IronMQ/IronMqRestClient.cs
@@ -8,9 +8,11 @@ namespace IronSharp.IronMQ
     public class IronMqRestClient
     {
         private readonly IronClientConfig _config;
+        private readonly RestClient _restClient;
 
         internal IronMqRestClient(IronClientConfig config)
         {
+            _restClient = new RestClient();
             _config = LazyInitializer.EnsureInitialized(ref config);
 
             if (string.IsNullOrEmpty(Config.Host))
@@ -27,6 +29,11 @@ namespace IronSharp.IronMQ
         public IronClientConfig Config
         {
             get { return _config; }
+        }
+
+        public RestClient RestClient
+        {
+            get { return _restClient; }
         }
 
         public string EndPoint
@@ -54,7 +61,7 @@ namespace IronSharp.IronMQ
         /// <returns> </returns>
         public IEnumerable<QueueInfo> Queues(PagingFilter filter = null)
         {
-            return RestClient.Get<IEnumerable<QueueInfo>>(_config, EndPoint, filter).Result;
+            return _restClient.Get<IEnumerable<QueueInfo>>(_config, EndPoint, filter).Result;
         }
     }
 }

--- a/src/IronSharp.IronMQ/QueueClient.cs
+++ b/src/IronSharp.IronMQ/QueueClient.cs
@@ -126,11 +126,13 @@ namespace IronSharp.IronMQ
     {
         private readonly IronMqRestClient _client;
         private readonly string _name;
+        protected readonly RestClient _restClient; 
 
         public QueueClient(IronMqRestClient client, string name)
         {
             _client = client;
             _name = name;
+            _restClient = client.RestClient;
         }
 
         public string EndPoint
@@ -153,7 +155,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public bool Clear()
         {
-            return RestClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/clear", EndPoint)).HasExpectedMessage("Cleared.");
+            return _restClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/clear", EndPoint)).HasExpectedMessage("Cleared.");
         }
 
         /// <summary>
@@ -164,7 +166,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public bool Delete()
         {
-            return RestClient.Delete<ResponseMsg>(_client.Config, EndPoint).HasExpectedMessage("Deleted.");
+            return _restClient.Delete<ResponseMsg>(_client.Config, EndPoint).HasExpectedMessage("Deleted.");
         }
 
         /// <summary>
@@ -175,7 +177,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public QueueInfo Info()
         {
-            return RestClient.Get<QueueInfo>(_client.Config, EndPoint);
+            return _restClient.Get<QueueInfo>(_client.Config, EndPoint);
         }
 
         /// <summary>
@@ -188,7 +190,7 @@ namespace IronSharp.IronMQ
         /// <returns> </returns>
         public QueueInfo Update(QueueInfo updates)
         {
-            return RestClient.Post<QueueInfo>(_client.Config, EndPoint, updates);
+            return _restClient.Post<QueueInfo>(_client.Config, EndPoint, updates);
         }
 
         #endregion
@@ -204,7 +206,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public bool Delete(string messageId)
         {
-            return RestClient.Delete<ResponseMsg>(_client.Config, string.Format("{0}/messages/{1}", EndPoint, messageId)).HasExpectedMessage("Deleted");
+            return _restClient.Delete<ResponseMsg>(_client.Config, string.Format("{0}/messages/{1}", EndPoint, messageId)).HasExpectedMessage("Deleted");
         }
 
         /// <summary>
@@ -217,7 +219,7 @@ namespace IronSharp.IronMQ
         public bool Delete(IEnumerable<string> messageIds)
         {
             return
-                RestClient.Delete<ResponseMsg>(_client.Config, string.Format("{0}/messages", EndPoint), payload: new MessageIdCollection(messageIds)).HasExpectedMessage("Deleted");
+                _restClient.Delete<ResponseMsg>(_client.Config, string.Format("{0}/messages", EndPoint), payload: new MessageIdCollection(messageIds)).HasExpectedMessage("Deleted");
         }
 
         /// <summary>
@@ -229,7 +231,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public QueueMessage Get(string messageId)
         {
-            return RestClient.Get<QueueMessage>(_client.Config, string.Format("{0}/messages/{1}", EndPoint, messageId));
+            return _restClient.Get<QueueMessage>(_client.Config, string.Format("{0}/messages/{1}", EndPoint, messageId));
         }
 
         /// <summary>
@@ -307,7 +309,7 @@ namespace IronSharp.IronMQ
                 query.Add("wait", Convert.ToString(wait));
             }
 
-            RestResponse<MessageCollection> result = RestClient.Get<MessageCollection>(_client.Config, string.Format("{0}/messages", EndPoint), query);
+            RestResponse<MessageCollection> result = _restClient.Get<MessageCollection>(_client.Config, string.Format("{0}/messages", EndPoint), query);
 
             if (result.CanReadResult())
             {
@@ -396,7 +398,7 @@ namespace IronSharp.IronMQ
                 query.Add("n", Convert.ToString(n));
             }
 
-            RestResponse<MessageCollection> result = RestClient.Get<MessageCollection>(_client.Config, string.Format("{0}/messages/peek", EndPoint), query);
+            RestResponse<MessageCollection> result = _restClient.Get<MessageCollection>(_client.Config, string.Format("{0}/messages/peek", EndPoint), query);
 
 
             if (result.CanReadResult())
@@ -461,7 +463,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public MessageIdCollection Post(MessageCollection messageCollection)
         {
-            return RestClient.Post<MessageIdCollection>(_client.Config, string.Format("{0}/messages", EndPoint), messageCollection);
+            return _restClient.Post<MessageIdCollection>(_client.Config, string.Format("{0}/messages", EndPoint), messageCollection);
         }
 
         /// <summary>
@@ -517,7 +519,7 @@ namespace IronSharp.IronMQ
         public bool Release(string messageId, int? delay = null)
         {
             var query = new MessageOptions { Delay = delay };
-            return RestClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/messages/{1}/release", EndPoint, messageId), query).HasExpectedMessage("Released");
+            return _restClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/messages/{1}/release", EndPoint, messageId), query).HasExpectedMessage("Released");
         }
 
         /// <summary>
@@ -529,7 +531,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public bool Touch(string messageId)
         {
-            return RestClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/messages/{1}/touch", EndPoint, messageId)).HasExpectedMessage("Touched");
+            return _restClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/messages/{1}/touch", EndPoint, messageId)).HasExpectedMessage("Touched");
         }
 
         /// <summary>
@@ -543,7 +545,7 @@ namespace IronSharp.IronMQ
                 EndPoint = string.Format("{0}/messages/webhook", EndPoint),
                 AuthTokenLocation = AuthTokenLocation.Querystring
             };
-            return RestClient.BuildRequestUri(_client.Config, request, token);
+            return _restClient.BuildRequestUri(_client.Config, request, token);
         }
 
         private MessageCollection LinkMessageCollection(RestResponse<MessageCollection> response)
@@ -571,7 +573,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public QueueInfo AddAlerts(AlertCollection alertCollection)
         {
-            return RestClient.Post<QueueInfo>(_client.Config, string.Format("{0}/alerts", EndPoint), alertCollection);
+            return _restClient.Post<QueueInfo>(_client.Config, string.Format("{0}/alerts", EndPoint), alertCollection);
         }
 
         /// <summary>
@@ -583,7 +585,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public QueueInfo UpdateAlerts(AlertCollection alertCollection)
         {
-            return RestClient.Put<QueueInfo>(_client.Config, string.Format("{0}/alerts", EndPoint), alertCollection);
+            return _restClient.Put<QueueInfo>(_client.Config, string.Format("{0}/alerts", EndPoint), alertCollection);
         }
 
         /// <summary>
@@ -613,7 +615,7 @@ namespace IronSharp.IronMQ
         {
             if (String.IsNullOrEmpty(alertId))
                 return false;
-            return RestClient.Delete<ResponseMsg>(_client.Config, string.Format("{0}/alerts/{1}", EndPoint, alertId)).HasExpectedMessage("Deleted");
+            return _restClient.Delete<ResponseMsg>(_client.Config, string.Format("{0}/alerts/{1}", EndPoint, alertId)).HasExpectedMessage("Deleted");
         }
 
         /// <summary>
@@ -624,7 +626,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public QueueInfo RemoveAlerts(AlertCollection alertCollection)
         {
-            return RestClient.Delete<QueueInfo>(_client.Config, string.Format("{0}/alerts", EndPoint), payload: alertCollection);
+            return _restClient.Delete<QueueInfo>(_client.Config, string.Format("{0}/alerts", EndPoint), payload: alertCollection);
         }
 
         #endregion
@@ -640,7 +642,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public QueueInfo AddSubscribers(SubscriberCollection subscriberCollection)
         {
-            return RestClient.Post<QueueInfo>(_client.Config, string.Format("{0}/subscribers", EndPoint), subscriberCollection);
+            return _restClient.Post<QueueInfo>(_client.Config, string.Format("{0}/subscribers", EndPoint), subscriberCollection);
         }
 
         /// <summary>
@@ -654,7 +656,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public bool Delete(string messageId, string subscriberId)
         {
-            return RestClient.Get<ResponseMsg>(_client.Config, string.Format("{0}/messages/{1}/subscribers/{2}", EndPoint, messageId, subscriberId)).HasExpectedMessage("Deleted");
+            return _restClient.Get<ResponseMsg>(_client.Config, string.Format("{0}/messages/{1}/subscribers/{2}", EndPoint, messageId, subscriberId)).HasExpectedMessage("Deleted");
         }
 
         /// <summary>
@@ -667,7 +669,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public SubscriberCollection PushStatus(string messageId)
         {
-            return RestClient.Get<SubscriberCollection>(_client.Config, string.Format("{0}/messages/{1}/subscribers", EndPoint, messageId));
+            return _restClient.Get<SubscriberCollection>(_client.Config, string.Format("{0}/messages/{1}/subscribers", EndPoint, messageId));
         }
 
         /// <summary>
@@ -678,7 +680,7 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public QueueInfo RemoveSubscribers(SubscriberCollection subscriberCollection)
         {
-            return RestClient.Delete<QueueInfo>(_client.Config, string.Format("{0}/subscribers", EndPoint), payload: subscriberCollection);
+            return _restClient.Delete<QueueInfo>(_client.Config, string.Format("{0}/subscribers", EndPoint), payload: subscriberCollection);
         }
 
         #endregion

--- a/src/IronSharp.IronWorker/Code/CodeClient.cs
+++ b/src/IronSharp.IronWorker/Code/CodeClient.cs
@@ -10,11 +10,13 @@ namespace IronSharp.IronWorker
     {
         private readonly IronWorkerRestClient _client;
         private readonly string _codeId;
+        protected readonly RestClient _restClient; 
 
         public CodeClient(IronWorkerRestClient client, string codeId)
         {
             _client = client;
             _codeId = codeId;
+            _restClient = client.RestClient;
         }
 
         public string EndPoint
@@ -30,7 +32,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public bool Delete()
         {
-            return RestClient.Delete<ResponseMsg>(_client.Config, EndPoint).HasExpectedMessage("Deleted");
+            return _restClient.Delete<ResponseMsg>(_client.Config, EndPoint).HasExpectedMessage("Deleted");
         }
 
         /// <summary>
@@ -41,7 +43,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public Task<HttpResponseMessage> Download()
         {
-            return RestClient.Execute(_client.Config, new RestClientRequest
+            return _restClient.Execute(_client.Config, new RestClientRequest
             {
                 EndPoint = EndPoint + "/download",
                 Method = HttpMethod.Get,
@@ -57,7 +59,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public CodeInfo Info()
         {
-            return RestClient.Get<CodeInfo>(_client.Config, EndPoint);
+            return _restClient.Get<CodeInfo>(_client.Config, EndPoint);
         }
 
         public RevisionCollection Revisions(int? page = null, int? perPage = null)
@@ -73,7 +75,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public RevisionCollection Revisions(PagingFilter filter = null)
         {
-            return RestClient.Get<RevisionCollection>(_client.Config, EndPoint + "/revisions", filter);
+            return _restClient.Get<RevisionCollection>(_client.Config, EndPoint + "/revisions", filter);
         }
 
         /// <summary>
@@ -84,7 +86,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public Task<HttpResponseMessage> Upload(Stream zipFile, WorkerOptions options)
         {
-            return RestClient.Execute(_client.Config, new RestClientRequest
+            return _restClient.Execute(_client.Config, new RestClientRequest
             {
                 EndPoint = EndPoint,
                 Method = HttpMethod.Post,

--- a/src/IronSharp.IronWorker/IronWorkerRestClient.cs
+++ b/src/IronSharp.IronWorker/IronWorkerRestClient.cs
@@ -6,11 +6,13 @@ namespace IronSharp.IronWorker
     public class IronWorkerRestClient
     {
         private readonly IronClientConfig _config;
+        protected readonly RestClient _restClient; 
 
         internal IronWorkerRestClient(IronClientConfig config)
         {
             _config = LazyInitializer.EnsureInitialized(ref config);
-
+            _restClient = new RestClient();
+    
             if (string.IsNullOrEmpty(Config.Host))
             {
                 Config.Host = IronWorkCloudHosts.DEFAULT;
@@ -25,6 +27,11 @@ namespace IronSharp.IronWorker
         public IronClientConfig Config
         {
             get { return _config; }
+        }
+
+        public RestClient RestClient
+        {
+            get { return _restClient; }
         }
 
         public string EndPoint
@@ -57,7 +64,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public CodeInfoCollection Codes(PagingFilter filter = null)
         {
-            return RestClient.Get<CodeInfoCollection>(_config, string.Format("{0}/codes", EndPoint), filter).Result;
+            return _restClient.Get<CodeInfoCollection>(_config, string.Format("{0}/codes", EndPoint), filter).Result;
         }
 
         #endregion

--- a/src/IronSharp.IronWorker/Schedules/ScheduleClient.cs
+++ b/src/IronSharp.IronWorker/Schedules/ScheduleClient.cs
@@ -7,6 +7,7 @@ namespace IronSharp.IronWorker
     public class ScheduleClient
     {
         private readonly IronWorkerRestClient _client;
+        protected readonly RestClient _restClient; 
 
         public ScheduleClient(IronWorkerRestClient client)
         {
@@ -14,6 +15,7 @@ namespace IronSharp.IronWorker
             Contract.EndContractBlock();
 
             _client = client;
+            _restClient = client.RestClient;
         }
 
         public string EndPoint
@@ -28,7 +30,7 @@ namespace IronSharp.IronWorker
 
         public bool Cancel(string scheduleId)
         {
-            return RestClient.Post<ResponseMsg>(_client.Config, ScheduleEndPoint(scheduleId) + "/cancel").HasExpectedMessage("Cancelled");
+            return _restClient.Post<ResponseMsg>(_client.Config, ScheduleEndPoint(scheduleId) + "/cancel").HasExpectedMessage("Cancelled");
         }
 
         public ScheduleIdCollection Create(string codeName, object payload, ScheduleOptions options)
@@ -43,12 +45,12 @@ namespace IronSharp.IronWorker
 
         public ScheduleIdCollection Create(SchedulePayloadCollection collection)
         {
-            return RestClient.Post<ScheduleIdCollection>(_client.Config, EndPoint, collection);
+            return _restClient.Post<ScheduleIdCollection>(_client.Config, EndPoint, collection);
         }
 
         public ScheduleInfo Get(string scheduleId)
         {
-            return RestClient.Get<ScheduleInfo>(_client.Config, ScheduleEndPoint(scheduleId));
+            return _restClient.Get<ScheduleInfo>(_client.Config, ScheduleEndPoint(scheduleId));
         }
 
         /// <summary>
@@ -60,7 +62,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public ScheduleInfoCollection List(PagingFilter filter = null)
         {
-            return RestClient.Get<ScheduleInfoCollection>(_client.Config, EndPoint, filter);
+            return _restClient.Get<ScheduleInfoCollection>(_client.Config, EndPoint, filter);
         }
 
         public string ScheduleEndPoint(string scheduleId)

--- a/src/IronSharp.IronWorker/Tasks/TaskClient.cs
+++ b/src/IronSharp.IronWorker/Tasks/TaskClient.cs
@@ -10,6 +10,7 @@ namespace IronSharp.IronWorker
     public class TaskClient
     {
         private readonly IronWorkerRestClient _client;
+        protected readonly RestClient _restClient; 
 
         public TaskClient(IronWorkerRestClient client)
         {
@@ -17,6 +18,7 @@ namespace IronSharp.IronWorker
             Contract.EndContractBlock();
 
             _client = client;
+            _restClient = client.RestClient;
         }
 
         public string EndPoint
@@ -38,7 +40,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public bool Cancel(string taskId)
         {
-            return RestClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/cancel", TaskEndPoint(taskId))).HasExpectedMessage("Cancelled");
+            return _restClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/cancel", TaskEndPoint(taskId))).HasExpectedMessage("Cancelled");
         }
 
         /// <summary>
@@ -106,7 +108,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public TaskIdCollection Create(TaskPayloadCollection collection)
         {
-            return RestClient.Post<TaskIdCollection>(_client.Config, EndPoint, collection);
+            return _restClient.Post<TaskIdCollection>(_client.Config, EndPoint, collection);
         }
 
         /// <summary>
@@ -118,7 +120,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public TaskInfo Get(string taskId)
         {
-            return RestClient.Get<TaskInfo>(_client.Config, TaskEndPoint(taskId));
+            return _restClient.Get<TaskInfo>(_client.Config, TaskEndPoint(taskId));
         }
 
         /// <summary>
@@ -144,7 +146,7 @@ namespace IronSharp.IronWorker
                 ApplyStatusFilter(query, filter.Status);
             }
 
-            return RestClient.Get<TaskInfoCollection>(_client.Config, EndPoint, query).Result;
+            return _restClient.Get<TaskInfoCollection>(_client.Config, EndPoint, query).Result;
         }
 
         /// <summary>
@@ -156,7 +158,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public string Log(string taskId)
         {
-            return RestClient.Get<string>(_client.Config, string.Format("{0}/log", TaskEndPoint(taskId))).Content.ReadAsStringAsync().Result;
+            return _restClient.Get<string>(_client.Config, string.Format("{0}/log", TaskEndPoint(taskId))).Content.ReadAsStringAsync().Result;
         }
 
         /// <summary>
@@ -169,7 +171,7 @@ namespace IronSharp.IronWorker
         /// </remarks>
         public bool Progress(string taskId, TaskProgress taskProgress)
         {
-            return RestClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/progress", TaskEndPoint(taskId)), taskProgress).HasExpectedMessage("Progress set");
+            return _restClient.Post<ResponseMsg>(_client.Config, string.Format("{0}/progress", TaskEndPoint(taskId)), taskProgress).HasExpectedMessage("Progress set");
         }
 
         /// <summary>
@@ -189,7 +191,7 @@ namespace IronSharp.IronWorker
                 payload = new {delay};
             }
 
-            return RestClient.Post<TaskIdCollection>(_client.Config, string.Format("{0}/retry", TaskEndPoint(taskId)), payload);
+            return _restClient.Post<TaskIdCollection>(_client.Config, string.Format("{0}/retry", TaskEndPoint(taskId)), payload);
         }
 
         public string TaskEndPoint(string taskId)
@@ -210,7 +212,7 @@ namespace IronSharp.IronWorker
                     {"code_name", codeName}
                 }
             };
-            return RestClient.BuildRequestUri(_client.Config, request, token);
+            return _restClient.BuildRequestUri(_client.Config, request, token);
         }
 
         private static void ApplyDateRangeFilters(NameValueCollection query, DateTime? fromTime, DateTime? toTime)


### PR DESCRIPTION
Some of our customers asked for preserving instance of `HttpClient` within each instance of API clients (mq/worker/cache). So now HttpClient isn't instantiated for each request.