### PR TITLE
Long polling bugfix. Wait parameter was not part of payload.

### DIFF
--- a/src/IronSharp.IronMQ/QueueClient.cs
+++ b/src/IronSharp.IronMQ/QueueClient.cs
@@ -326,13 +326,12 @@ namespace IronSharp.IronMQ
         /// </remarks>
         public MessageCollection Get(int? n = null, int? timeout = null, int? wait = null)
         {
-            var query = new NameValueCollection();
-
             var payload = new Dictionary<string, object>();
             if (n.HasValue)
             {
                 payload.Add("n", n);
             }
+
             if (timeout.HasValue)
             {
                 payload.Add("timeout", timeout);
@@ -340,10 +339,10 @@ namespace IronSharp.IronMQ
 
             if (wait.HasValue)
             {
-                query.Add("wait", Convert.ToString(wait));
+                payload.Add("wait", wait);
             }
 
-            RestResponse<MessageCollection> result = _restClient.Post<MessageCollection>(_client.Config, string.Format("{0}/reservations", EndPoint), payload, query);
+            RestResponse<MessageCollection> result = _restClient.Post<MessageCollection>(_client.Config, string.Format("{0}/reservations", EndPoint), payload);
 
             if (result.CanReadResult())
             {


### PR DESCRIPTION
I couldn't  get long polling to work, it looks like the wait parameter was handled wrong. It was sent as an url parameter instead of part of the POST'ed body and it seems to be ignored as url parameter.

The fix was simply adding wait to the payload and now long polling works as expected.